### PR TITLE
Update gridsome.server.js missing fields on Author

### DIFF
--- a/gridsome.server.js
+++ b/gridsome.server.js
@@ -38,7 +38,7 @@ module.exports = function (api) {
       authors.addNode({
         id,
         title,
-        fields,
+        ...fields,
         internal: {
           origin: authorsPath
         }


### PR DESCRIPTION
Error on encountered on netlify build


An error occurred while executing page-query for src/templates/BlogPost.vue
Error: Cannot query field "avatar" on type "Author".
GraphQL request:29:7
28 |       path,
29 |       avatar (width: 60)